### PR TITLE
fix typo when missing github token

### DIFF
--- a/to_gist
+++ b/to_gist
@@ -38,11 +38,11 @@
         echo $to_gist_url
       fi
     else
-      echo "togist: Missing GITUB_TOKEN."
+      echo "to_gist: Missing GITHUB_TOKEN."
       echo "See https://help.github.com/articles/creating-an-access-token-for-command-line-use/"
     fi
   else
-    echo "togist: Missing one of the following dependencies:"
+    echo "to_gist: Missing one of the following dependencies:"
     echo "* curl"
     echo "* jq"
     echo ""


### PR DESCRIPTION
Fix small typos in CLI messages.
